### PR TITLE
Unify graph query UI, fix Cytoscape headless errors, and improve export/preview UX

### DIFF
--- a/app/graph-export/GraphPreview.tsx
+++ b/app/graph-export/GraphPreview.tsx
@@ -1,52 +1,428 @@
-// app/components/GraphPreview.tsx
-import React, { useEffect, useRef } from "react";
-import cytoscape, { ElementDefinition } from "cytoscape";
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import cytoscape, { Core, ElementDefinition, NodeSingular } from "cytoscape";
+
+type LayoutName = "breadthfirst" | "cose" | "grid" | "circle";
 
 interface GraphPreviewProps {
   elements: ElementDefinition[];
+  initialLayout?: LayoutName;
+  height?: number | string;
 }
 
-export function GraphPreview({ elements }: GraphPreviewProps) {
-  const cyRef = useRef<HTMLDivElement>(null);
+const TYPE_COLORS: Record<string, string> = {
+  Function: "#2563eb",
+  Class: "#9333ea",
+  Call: "#0891b2",
+  If: "#f59e0b",
+  Loop: "#16a34a",
+  Switch: "#ea580c",
+  Try: "#db2777",
+  Catch: "#be123c",
+  Contributor: "#64748b",
+};
+const DEFAULT_NODE_COLOR = "#0ea5e9";
 
-  useEffect(() => {
-    if (!cyRef.current || !elements.length) return;
-    let cy = cytoscape({
-      container: cyRef.current,
-      elements,
-      style: [
-        {
-          selector: "node",
-          style: {
-            label: "data(label)",
-            "background-color": "#0074D9"
-          }
+// quick validator to help catch bad edges
+function validateElements(els: ElementDefinition[]) {
+  const nodes = els.filter((e: any) => e.data && !e.data.source && !e.data.target);
+  const edges = els.filter((e: any) => e.data && (e.data.source || e.data.target));
+  for (const n of nodes) if (!n.data?.id) console.warn("Node missing data.id:", n);
+  const nodeIds = new Set(nodes.map((n: any) => n.data.id));
+  for (const e of edges) {
+    const d = (e as any).data || {};
+    if (!d.source || !d.target) console.warn("Edge missing source/target:", e);
+    if (!nodeIds.has(d.source) || !nodeIds.has(d.target)) console.warn("Edge points to unknown node(s):", e);
+  }
+  return true;
+}
+
+export function GraphPreview({ elements, initialLayout = "cose", height = 500 }: GraphPreviewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cyRef = useRef<Core | null>(null);
+  const createdRef = useRef(false);
+
+  const [layoutName, setLayoutName] = useState<LayoutName>(initialLayout);
+  const [selectedNodeData, setSelectedNodeData] = useState<any | null>(null);
+  const [selectedEdgeData, setSelectedEdgeData] = useState<any | null>(null);
+
+  // Dark-mode readable styles
+  const stylesheet = useMemo(
+    () => [
+      {
+        selector: "node",
+        style: {
+          label: "data(label)",
+          fontSize: 11,
+          textWrap: "wrap",
+          textMaxWidth: 180,
+          backgroundColor: (ele: NodeSingular) => {
+            const t = ele.data("type") as string | undefined;
+            return (t && TYPE_COLORS[t]) || DEFAULT_NODE_COLOR;
+          },
+          borderWidth: 1,
+          borderColor: "#1f2937",
+          color: "#e5e7eb",
+          textOutlineWidth: 2,
+          textOutlineColor: "#0b0f19",
+          textBackgroundColor: "#0b0f19",
+          textBackgroundOpacity: 0.6,
+          textBackgroundPadding: 2,
         },
-        {
-          selector: "edge",
-          style: {
-            width: 2,
-            "line-color": "#ccc",
-            "target-arrow-color": "#ccc",
-            "target-arrow-shape": "triangle"
-          }
-        }
-      ],
-      layout: { name: "cose" }
+      },
+      { selector: 'node[type = "Contributor"]', style: { shape: "round-rectangle" } },
+      {
+        selector: "edge",
+        style: {
+          width: 2,
+          lineColor: "#94a3b8",
+          targetArrowColor: "#94a3b8",
+          targetArrowShape: "triangle",
+          curveStyle: "bezier",
+          fontSize: 10,
+          textRotation: "autorotate",
+          textMarginY: -6,
+          color: "#cbd5e1",
+          textBackgroundColor: "#0b0f19",
+          textBackgroundOpacity: 0.6,
+          textBackgroundPadding: 2,
+          label: "data(relation)",
+        },
+      },
+      {
+        selector: "node:selected",
+        style: {
+          "border-width": 3,
+          "border-color": "#ffffff",
+          "background-color": (ele: NodeSingular) => {
+            const t = ele.data("type") as string | undefined;
+            return (t && TYPE_COLORS[t]) || DEFAULT_NODE_COLOR;
+          },
+          "background-blacken": 0,
+          color: "#e5e7eb",
+          "text-outline-width": 2,
+          "text-outline-color": "#0b0f19",
+          "text-background-color": "#0b0f19",
+          "text-background-opacity": 0.7,
+          "text-background-padding": 2,
+        },
+      },
+      { selector: "edge:selected", style: { width: 3, lineColor: "#ffffff", targetArrowColor: "#ffffff" } },
+    ],
+    []
+  );
+
+  // helpers to read actual rendered colors from cytoscape
+  const getNodeColor = (ele: any) => ele.style("background-color");
+  const getEdgeColor = (ele: any) => ele.style("line-color");
+
+  // create once
+  useEffect(() => {
+    if (typeof window === "undefined") return; // SSR guard
+    if (createdRef.current || !containerRef.current) return;
+
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements: [],
+      style: stylesheet as any,
+      // Use preset initially; run the chosen layout after elements are added
+      layout: { name: "preset" },
+      wheelSensitivity: 0.2,
+      pixelRatio: 1,
     });
-    return () => cy.destroy();
-  }, [elements]);
+
+    cyRef.current = cy;
+    createdRef.current = true;
+
+    // IMPORTANT: stash the actual color so the details panel can mirror the graph
+    cy.on("select", "node", (evt) => {
+      setSelectedEdgeData(null);
+      setSelectedNodeData({ ...evt.target.data(), color: getNodeColor(evt.target) });
+    });
+    cy.on("select", "edge", (evt) => {
+      setSelectedNodeData(null);
+      setSelectedEdgeData({ ...evt.target.data(), color: getEdgeColor(evt.target) });
+    });
+    cy.on("tap", (evt) => {
+      if (evt.target === cy) {
+        setSelectedNodeData(null);
+        setSelectedEdgeData(null);
+      }
+    });
+
+    return () => {
+      try {
+        try {
+          cy.stop();
+        } catch {}
+        cy.destroy();
+      } finally {
+        cyRef.current = null;
+        createdRef.current = false;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // update on data/layout change
+  useEffect(() => {
+    const cy = cyRef.current;
+    const container = containerRef.current;
+    if (!cy || cy.destroyed() || !container) return;
+
+    // if hidden or zero-sized, skip; we'll fit on the next visible paint
+    if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
+
+    if (!Array.isArray(elements) || elements.length === 0) {
+      cy.startBatch();
+      cy.elements().remove();
+      cy.endBatch();
+      return;
+    }
+
+    validateElements(elements);
+
+    cy.startBatch();
+    cy.elements().remove();
+    cy.add(elements as any);
+    cy.endBatch();
+
+    let canceled = false;
+
+    // ensure renderer knows actual size before layout/fit
+    cy.resize();
+
+    const lay = cy.layout({ name: layoutName });
+    lay.on("layoutstop", () => {
+      if (canceled || cy.destroyed()) return;
+      if (cy.nodes().length > 0) {
+        cy.fit(undefined, 30);
+      }
+    });
+
+    // kick to next frame to avoid running while sizing/DOM is settling
+    const id = requestAnimationFrame(() => {
+      if (!canceled && cy && !cy.destroyed()) lay.run();
+    });
+
+    return () => {
+      canceled = true;
+      try {
+        lay.stop();
+      } catch {}
+      cancelAnimationFrame(id);
+    };
+  }, [elements, layoutName]);
+
+  const runLayout = (name: LayoutName) => {
+    setLayoutName(name);
+    const cy = cyRef.current;
+    const container = containerRef.current;
+    if (!cy || cy.destroyed() || !container) return;
+    if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
+
+    cy.resize();
+
+    const lay = cy.layout({ name });
+    lay.on("layoutstop", () => {
+      if (!cy.destroyed() && cy.nodes().length > 0) cy.fit(undefined, 30);
+    });
+    requestAnimationFrame(() => {
+      if (cy && !cy.destroyed()) lay.run();
+    });
+  };
+
+  const handleFit = () => {
+    const cy = cyRef.current;
+    const container = containerRef.current;
+    if (!cy || cy.destroyed() || cy.nodes().length === 0 || !container) return;
+    cy.resize();
+    cy.fit(undefined, 30);
+  };
+
+  const handleExportPng = () => {
+    const cy = cyRef.current;
+    if (!cy || cy.destroyed()) return;
+    const png = cy.png({ full: true, scale: 2, bg: "#ffffff" });
+    const a = document.createElement("a");
+    a.href = png;
+    a.download = "graph.png";
+    a.click();
+  };
+
+  const detailsMaxH = typeof height === "number" ? `${height}px` : height;
 
   return (
-    <div
-      ref={cyRef}
-      style={{
-        width: "100%",
-        height: "500px",
-        border: "1px solid #ccc",
-        borderRadius: "10px",
-        background: "#fff"
-      }}
-    />
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 12 }}>
+      <div>
+        {/* toolbar */}
+        <div style={{ display: "flex", gap: 8, marginBottom: 8, alignItems: "center" }}>
+          <label style={{ fontSize: 12, color: "#9ca3af" }}>Layout</label>
+          <select
+            value={layoutName}
+            onChange={(e) => runLayout(e.target.value as LayoutName)}
+            style={{
+              padding: "6px 8px",
+              borderRadius: 8,
+              border: "1px solid #374151",
+              background: "transparent",
+              color: "#e5e7eb",
+            }}
+          >
+            <option value="cose">cose (force)</option>
+            <option value="breadthfirst">breadthfirst</option>
+            <option value="grid">grid</option>
+            <option value="circle">circle</option>
+          </select>
+
+          <button
+            onClick={handleFit}
+            style={{
+              padding: "6px 10px",
+              borderRadius: 8,
+              border: "1px solid #374151",
+              background: "transparent",
+              color: "#e5e7eb",
+              cursor: "pointer",
+            }}
+          >
+            Fit
+          </button>
+
+          <button
+            onClick={handleExportPng}
+            style={{
+              padding: "6px 10px",
+              borderRadius: 8,
+              border: "1px solid #374151",
+              background: "transparent",
+              color: "#e5e7eb",
+              cursor: "pointer",
+            }}
+          >
+            Export
+          </button>
+
+          <div style={{ marginLeft: "auto", display: "flex", gap: 10, alignItems: "center" }}>
+            {Object.entries(TYPE_COLORS).map(([t, c]) => (
+              <div key={t} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{
+                    display: "inline-block",
+                    width: 10,
+                    height: 10,
+                    background: c,
+                    borderRadius: 2,
+                    border: "1px solid #0b0f19",
+                  }}
+                />
+                <span style={{ fontSize: 11, color: "#9ca3af" }}>{t}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Graph canvas */}
+        <div
+          ref={containerRef}
+          style={{
+            width: "100%",
+            height: typeof height === "number" ? `${height}px` : height,
+            border: "1px solid #374151",
+            borderRadius: 10,
+            background: "#0b0f19",
+          }}
+        />
+      </div>
+
+      {/* Details panel mirrors actual colors */}
+      <div
+        style={{
+          border: "1px solid #e5e7eb",
+          borderRadius: 8,
+          padding: 12,
+          background: "#0b0f19",
+          color: "#e5e7eb",
+          overflowY: "auto",
+          maxHeight: detailsMaxH,
+        }}
+      >
+        {selectedNodeData ? (
+          <>
+            <h3 style={{ margin: "0 0 8px", fontSize: 16, display: "flex", alignItems: "center", gap: 8 }}>
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 14,
+                  height: 14,
+                  borderRadius: "50%",
+                  background: selectedNodeData.color || DEFAULT_NODE_COLOR,
+                  border: "1px solid #0b0f19",
+                }}
+              />
+              Node
+            </h3>
+            <div style={{ fontSize: 13, marginBottom: 8 }}>
+              <div>
+                <b>Type:</b> {selectedNodeData.type ?? "-"}
+              </div>
+              <div>
+                <b>Name:</b> {selectedNodeData.name ?? "-"}
+              </div>
+              <div>
+                <b>Location:</b> {selectedNodeData.location ?? "-"}
+              </div>
+            </div>
+            {selectedNodeData.code ? (
+              <>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>Code</div>
+                <pre
+                  style={{
+                    fontSize: 12,
+                    background: "#0b0f19",
+                    color: "#e5e7eb",
+                    padding: 8,
+                    borderRadius: 8,
+                    whiteSpace: "pre-wrap",
+                    overflowX: "auto",
+                    border: "1px solid #374151",
+                  }}
+                >
+                  {selectedNodeData.code}
+                </pre>
+              </>
+            ) : null}
+          </>
+        ) : selectedEdgeData ? (
+          <>
+            <h3 style={{ margin: "0 0 8px", fontSize: 16, display: "flex", alignItems: "center", gap: 8 }}>
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 18,
+                  height: 2,
+                  background: selectedEdgeData.color || "#94a3b8",
+                }}
+              />
+              Edge
+            </h3>
+            <div style={{ fontSize: 13, marginBottom: 8 }}>
+              <div>
+                <b>Relation:</b> {selectedEdgeData.relation ?? "-"}
+              </div>
+              <div>
+                <b>Source:</b> {selectedEdgeData.source ?? "-"}
+              </div>
+              <div>
+                <b>Target:</b> {selectedEdgeData.target ?? "-"}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div style={{ fontSize: 13, color: "#6b7280" }}>Select a node or edge to see details</div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/graph-export/page.tsx
+++ b/app/graph-export/page.tsx
@@ -1,355 +1,323 @@
-"use client"
+"use client";
 
-import {useEffect, useState} from "react"
-import {Calendar, Download, FileDown, GitBranch, GitCommit, GitMerge, Search} from "lucide-react"
+import { useEffect, useState } from "react";
+import { Calendar, Download, Search } from "lucide-react";
 
-import {Button} from "@/components/ui/button"
-import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from "@/components/ui/card"
-import {Input} from "@/components/ui/input"
-import {Label} from "@/components/ui/label"
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select"
-import {PageHeader} from "@/components/page-header"
-import {RadioGroup, RadioGroupItem} from "@/components/ui/radio-group"
-import {MainContent} from "@/components/main-content"
-import {GraphPreview} from "./GraphPreview";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { PageHeader } from "@/components/page-header";
+import { MainContent } from "@/components/main-content";
+import { GraphPreview } from "./GraphPreview";
 
-const API_BASE = "/api/backend/"
+const API_BASE = "/api/backend/";
 
-type BuildTask = {
-    repo_id: string
-    task_id: string
-    // ...other fields
-}
-
+type BuildTask = { repo_id: string; task_id: string };
 type Snapshot = {
-    snapshot_id: string
-    repo_id: string
-    commit_id?: string
-    s3_url?: string // json string of {graphml,json,nodes_csv,edges_csv}
-    // ...other fields
-}
+  snapshot_id: string;
+  repo_id: string;
+  commit_id?: string;
+  s3_url?: string; // stringified { graphml, json, nodes_csv, edges_csv }
+};
 
 export default function GraphExportPage() {
-    const [repos, setRepos] = useState<BuildTask[]>([])
-    const [snapshots, setSnapshots] = useState<Snapshot[]>([])
-    const [selectedRepo, setSelectedRepo] = useState<string>("")
-    const [selectedCommitId, setSelectedCommitId] = useState<string>("")
-    const [selectedSnapshot, setSelectedSnapshot] = useState<Snapshot | null>(null)
-    const [exportFormat, setExportFormat] = useState<"json" | "graphml" | "csv">("json")
-    const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [repos, setRepos] = useState<BuildTask[]>([]);
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [selectedRepo, setSelectedRepo] = useState("");
+  const [selectedCommitId, setSelectedCommitId] = useState("");
+  const [selectedSnapshot, setSelectedSnapshot] = useState<Snapshot | null>(null);
+  const [exportFormat, setExportFormat] = useState<"json" | "graphml" | "csv">("json");
+  const [isLoading, setIsLoading] = useState(false);
 
-    const [query, setQuery] = useState("");
-    const [previewElements, setPreviewElements] = useState<any[]>([]); // Cytoscape elements
-    const [previewLoading, setPreviewLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  const [previewElements, setPreviewElements] = useState<any[]>([]);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
-    function handleQuerySubmit() {
-        if (!selectedRepo || !selectedCommitId || !query) {
-            alert("Please select repo, commit, and enter a query.");
-            return;
-        }
-        setPreviewLoading(true);
-        fetch(`${API_BASE}/graph/subgraph?repoId=${encodeURIComponent(selectedRepo)}&commitId=${encodeURIComponent(selectedCommitId)}&q=${encodeURIComponent(query)}`)
-            .then(res => res.json())
-            .then(data => {
-                setPreviewElements(data.elements || []);
-            })
-            .catch(() => setPreviewElements([]))
-            .finally(() => setPreviewLoading(false));
-    }
+  const GRAPH_HEIGHT = 340; // fixed canvas height to keep layout stable
 
-    // Fetch all repos (build tasks)
-    useEffect(() => {
-        async function fetchRepos() {
-            try {
-                setIsLoading(true)
-                const res = await fetch(`${API_BASE}/graph/build`)
-                const data = await res.json()
-                // Always fallback to empty array if not an array
-                setRepos(Array.isArray(data) ? data : [])
-            } catch (e) {
-                setRepos([])
-            } finally {
-                setIsLoading(false)
-            }
-        }
-
-        fetchRepos()
-    }, [])
-
-    // Fetch all snapshots for selected repo
-    useEffect(() => {
-        if (!selectedRepo) {
-            setSnapshots([])
-            setSelectedCommitId("")
-            setSelectedSnapshot(null)
-            return
-        }
-
-        async function fetchSnapshots() {
-            try {
-                setIsLoading(true)
-                const res = await fetch(`${API_BASE}/graph/snapshots/by-repo/${encodeURIComponent(selectedRepo)}`)
-                const data = await res.json()
-                setSnapshots(data)
-            } catch (e) {
-                setSnapshots([])
-            } finally {
-                setIsLoading(false)
-            }
-        }
-
-        fetchSnapshots()
-    }, [selectedRepo])
-
-    // Find selected snapshot object
-    useEffect(() => {
-        if (!selectedCommitId || !snapshots.length) {
-            setSelectedSnapshot(null)
-            return
-        }
-        const snap = snapshots.find(s => (s.commit_id || "") === selectedCommitId)
-        setSelectedSnapshot(snap || null)
-    }, [selectedCommitId, snapshots])
-
-    // Reset all state
-    function handleReset() {
-        setSelectedRepo("")
-        setSelectedCommitId("")
-        setSelectedSnapshot(null)
-        setSnapshots([])
-        setExportFormat("json")
-    }
-
-    // Download graph
-    async function handleDownload(format: "json" | "graphml" | "csv") {
-        if (!selectedSnapshot?.s3_url) return;
-        try {
-            const urls = JSON.parse(selectedSnapshot.s3_url);
-            if (format === "csv") {
-                // Download nodes CSV
-                if (urls.nodes_csv) {
-                    const res1 = await fetch(urls.nodes_csv);
-                    const blob1 = await res1.blob();
-                    const link1 = document.createElement("a");
-                    link1.href = URL.createObjectURL(blob1);
-                    link1.download = `graph_snapshot_${selectedSnapshot.snapshot_id}_nodes.csv`;
-                    document.body.appendChild(link1);
-                    link1.click();
-                    setTimeout(() => {
-                        URL.revokeObjectURL(link1.href);
-                        document.body.removeChild(link1);
-                    }, 100);
-                }
-                // Download edges CSV
-                if (urls.edges_csv) {
-                    const res2 = await fetch(urls.edges_csv);
-                    const blob2 = await res2.blob();
-                    const link2 = document.createElement("a");
-                    link2.href = URL.createObjectURL(blob2);
-                    link2.download = `graph_snapshot_${selectedSnapshot.snapshot_id}_edges.csv`;
-                    document.body.appendChild(link2);
-                    link2.click();
-                    setTimeout(() => {
-                        URL.revokeObjectURL(link2.href);
-                        document.body.removeChild(link2);
-                    }, 100);
-                }
-                return; // Don't continue
-            }
-            // JSON/GraphML single file
-            let url = "";
-            let filename = "";
-            if (format === "json") {
-                url = urls.json;
-                filename = `graph_snapshot_${selectedSnapshot.snapshot_id}.json`;
-            } else if (format === "graphml") {
-                url = urls.graphml;
-                filename = `graph_snapshot_${selectedSnapshot.snapshot_id}.graphml`;
-            }
-            if (url) {
-                const response = await fetch(url);
-                const blob = await response.blob();
-                const link = document.createElement("a");
-                link.href = URL.createObjectURL(blob);
-                link.download = filename;
-                document.body.appendChild(link);
-                link.click();
-                setTimeout(() => {
-                    URL.revokeObjectURL(link.href);
-                    document.body.removeChild(link);
-                }, 100);
-            }
-        } catch (e) {
-            alert("Failed to download file.");
-        }
-    }
-
-    // Render commit id options
-    const commitIds = snapshots.map(s => s.commit_id).filter(Boolean)
-
-    return (
-        <div className="flex flex-col min-h-screen">
-            <PageHeader title="Graph Export" description="Export and visualize your repository dependencies">
-                <div className="flex flex-col sm:flex-row gap-2">
-                    <Button variant="outline" size="sm" className="sm:w-auto">
-                        <Calendar className="mr-2 h-4 w-4"/>
-                        History
-                    </Button>
-                </div>
-            </PageHeader>
-
-            <MainContent>
-                <div className="flex flex-col gap-4 mb-4">
-                    <h2 className="text-xl font-bold tracking-tight">Export Configuration</h2>
-                </div>
-                <div className="grid gap-6 sm:grid-cols-2">
-                    <div className="grid gap-6">
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>Export Settings</CardTitle>
-                                <CardDescription>Configure your graph export settings</CardDescription>
-                            </CardHeader>
-                            <CardContent>
-                                <div className="space-y-4">
-                                    <div className="space-y-2">
-                                        <Label htmlFor="repo-select">Select Repository</Label>
-                                        <Select value={selectedRepo} onValueChange={(val) => setSelectedRepo(val)}>
-                                            <SelectTrigger id="repo-select">
-                                                <SelectValue placeholder="Select a repository"/>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {repos.map(repo =>
-                                                    <SelectItem key={repo.repo_id} value={repo.repo_id}>
-                                                        {repo.repo_id}
-                                                    </SelectItem>
-                                                )}
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="commit-range">Commit</Label>
-                                        <Select value={selectedCommitId} onValueChange={setSelectedCommitId}
-                                                disabled={!commitIds.length}>
-                                            <SelectTrigger id="commit-range">
-                                                <SelectValue placeholder="Select commit"/>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {commitIds.map((commitId: string | undefined, idx: number) =>
-                                                    <SelectItem
-                                                        key={`${commitId ?? "unknown"}-${idx}`}
-                                                        value={commitId ?? ""}
-                                                    >
-                                                        {commitId ?? "(no commit id)"}
-                                                    </SelectItem>
-                                                )}
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label>Export Format</Label>
-                                        <RadioGroup
-                                            value={exportFormat}
-                                            onValueChange={val => setExportFormat(val as "json" | "graphml" | "csv")}
-                                            className="flex flex-col space-y-1"
-                                        >
-                                            <div className="flex items-center space-x-2">
-                                                <RadioGroupItem value="json" id="json"/>
-                                                <Label htmlFor="json">JSON</Label>
-                                            </div>
-                                            <div className="flex items-center space-x-2">
-                                                <RadioGroupItem value="graphml" id="graphml"/>
-                                                <Label htmlFor="graphml">GraphML</Label>
-                                            </div>
-                                            <div className="flex items-center space-x-2">
-                                                <RadioGroupItem value="csv" id="csv"/>
-                                                <Label htmlFor="csv">CSV (Nodes & Edges)</Label>
-                                            </div>
-                                        </RadioGroup>
-                                    </div>
-                                    <Button
-                                        className="sm:w-auto"
-                                        onClick={() => handleDownload(exportFormat)}
-                                        disabled={!selectedSnapshot}
-                                    >
-                                        <Download className="mr-2 h-4 w-4"/>
-                                        Export Graph
-                                    </Button>
-                                </div>
-                            </CardContent>
-                        </Card>
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>Recent Exports</CardTitle>
-                            </CardHeader>
-                            <CardContent>
-                                <div className="space-y-4">
-                                    {/* Optionally show history here */}
-                                    {repos.slice(0, 3).map((repo, idx) => (
-                                        <div key={repo.repo_id + idx}
-                                             className="flex items-center justify-between rounded-lg border p-3">
-                                            <div className="flex items-center gap-2">
-                                                <GitBranch className="h-4 w-4 text-muted-foreground"/>
-                                                <span className="text-sm font-medium">{repo.repo_id}</span>
-                                            </div>
-                                            <Button variant="ghost" size="icon">
-                                                <FileDown className="h-4 w-4"/>
-                                            </Button>
-                                        </div>
-                                    ))}
-                                </div>
-                            </CardContent>
-                        </Card>
-                    </div>
-                    <Card className="h-full">
-                        <CardHeader>
-                            <CardTitle>Graph Preview</CardTitle>
-                            <CardDescription>
-                                {selectedRepo && selectedCommitId
-                                    ? `Visualizing ${selectedRepo}@${selectedCommitId}`
-                                    : "Select a repository and commit to preview its graph"}
-                            </CardDescription>
-                        </CardHeader>
-                        <div className="flex gap-2 mb-2">
-                            <Input
-                                placeholder="Enter graph query (e.g., function name, node id...)"
-                                value={query}
-                                onChange={e => setQuery(e.target.value)}
-                                className="w-full"
-                            />
-                            <Button onClick={handleQuerySubmit} disabled={!selectedRepo || !selectedCommitId || !query}>
-                                <Search className="mr-2 h-4 w-4"/>
-                                Query
-                            </Button>
-                        </div>
-                        <CardContent className="h-[500px] flex items-center justify-center">
-                            {previewLoading ? (
-                                <div>Loading...</div>
-                            ) : previewElements.length > 0 ? (
-                                <GraphPreview elements={previewElements}/>
-                            ) : (
-                                <div className="text-center p-6">
-                                    <div
-                                        className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-muted">
-                                        <GitCommit className="h-10 w-10 text-muted-foreground"/>
-                                    </div>
-                                    <h3 className="mt-4 text-lg font-medium">No Repository Selected</h3>
-                                    <p className="mt-2 text-sm text-muted-foreground">
-                                        Select a repository and configure your export settings to generate a graph
-                                        preview.
-                                    </p>
-                                </div>
-                            )}
-                        </CardContent>
-                        <CardFooter className="flex justify-between">
-                            <Button variant="outline" onClick={handleReset}>Reset</Button>
-                            <Button onClick={() => handleDownload("graphml")} disabled={!selectedSnapshot}>
-                                <Download className="mr-2 h-4 w-4"/>
-                                Download GraphML
-                            </Button>
-                        </CardFooter>
-                    </Card>
-                </div>
-            </MainContent>
-        </div>
+  function handleQuerySubmit() {
+    if (!selectedRepo || !selectedCommitId || !query) return;
+    setPreviewLoading(true);
+    fetch(
+      `${API_BASE}/graph/subgraph?repoId=${encodeURIComponent(selectedRepo)}&commitId=${encodeURIComponent(
+        selectedCommitId
+      )}&q=${encodeURIComponent(query)}`
     )
+      .then((res) => res.json())
+      .then((data) => setPreviewElements(data.elements || []))
+      .catch(() => setPreviewElements([]))
+      .finally(() => setPreviewLoading(false));
+  }
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setIsLoading(true);
+        const res = await fetch(`${API_BASE}/graph/build`);
+        const data = await res.json();
+        setRepos(Array.isArray(data) ? data : []);
+      } catch {
+        setRepos([]);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRepo) {
+      setSnapshots([]);
+      setSelectedCommitId("");
+      setSelectedSnapshot(null);
+      return;
+    }
+    (async () => {
+      try {
+        setIsLoading(true);
+        const res = await fetch(`${API_BASE}/graph/snapshots/by-repo/${encodeURIComponent(selectedRepo)}`);
+        const data = await res.json();
+        setSnapshots(data);
+      } catch {
+        setSnapshots([]);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [selectedRepo]);
+
+  useEffect(() => {
+    if (!selectedCommitId || !snapshots.length) {
+      setSelectedSnapshot(null);
+      return;
+    }
+    const snap = snapshots.find((s) => (s.commit_id || "") === selectedCommitId);
+    setSelectedSnapshot(snap || null);
+  }, [selectedCommitId, snapshots]);
+
+  function handleReset() {
+    setSelectedRepo("");
+    setSelectedCommitId("");
+    setSelectedSnapshot(null);
+    setSnapshots([]);
+    setExportFormat("json");
+    setPreviewElements([]);
+    setQuery("");
+  }
+
+  async function handleDownload(format: "json" | "graphml" | "csv") {
+    if (!selectedSnapshot?.s3_url) return;
+    try {
+      const urls = JSON.parse(selectedSnapshot.s3_url);
+
+      if (format === "csv") {
+        if (urls.nodes_csv) {
+          const res1 = await fetch(urls.nodes_csv);
+          const blob1 = await res1.blob();
+          const link1 = document.createElement("a");
+          link1.href = URL.createObjectURL(blob1);
+          link1.download = `graph_snapshot_${selectedSnapshot.snapshot_id}_nodes.csv`;
+          document.body.appendChild(link1);
+          link1.click();
+          setTimeout(() => {
+            URL.revokeObjectURL(link1.href);
+            document.body.removeChild(link1);
+          }, 100);
+        }
+        if (urls.edges_csv) {
+          const res2 = await fetch(urls.edges_csv);
+          const blob2 = await res2.blob();
+          const link2 = document.createElement("a");
+          link2.href = URL.createObjectURL(blob2);
+          link2.download = `graph_snapshot_${selectedSnapshot.snapshot_id}_edges.csv`;
+          document.body.appendChild(link2);
+          link2.click();
+          setTimeout(() => {
+            URL.revokeObjectURL(link2.href);
+            document.body.removeChild(link2);
+          }, 100);
+        }
+        return;
+      }
+
+      let url = "";
+      let filename = "";
+      if (format === "json") {
+        url = urls.json;
+        filename = `graph_snapshot_${selectedSnapshot.snapshot_id}.json`;
+      } else if (format === "graphml") {
+        url = urls.graphml;
+        filename = `graph_snapshot_${selectedSnapshot.snapshot_id}.graphml`;
+      }
+      if (url) {
+        const response = await fetch(url);
+        const blob = await response.blob();
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        setTimeout(() => {
+          URL.revokeObjectURL(link.href);
+          document.body.removeChild(link);
+        }, 100);
+      }
+    } catch {
+      alert("Failed to download file.");
+    }
+  }
+
+  const commitIds = snapshots.map((s) => s.commit_id).filter(Boolean) as string[];
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <PageHeader title="Code Graph" description="Query your repository graph and explore results">
+        <div className="flex flex-col sm:flex-row gap-2">
+          <Button variant="outline" size="sm" className="sm:w-auto" disabled={isLoading}>
+            <Calendar className="mr-2 h-4 w-4" />
+            History
+          </Button>
+        </div>
+      </PageHeader>
+
+      <MainContent>
+        <Card className="h-fit">
+          <CardHeader className="pb-3">
+            <CardTitle>Query & Export</CardTitle>
+            <CardDescription>Select repo/commit, run a query, and export.</CardDescription>
+
+            {/* Combined, sticky controls */}
+            <div className="sticky top-0 z-10 -mx-6 mt-3 px-6 py-3 bg-background/90 backdrop-blur border-b border-border space-y-3">
+              {/* Row 1: repo / commit / format / export */}
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="min-w-[220px]">
+                  <Label htmlFor="repo-select" className="sr-only">
+                    Repository
+                  </Label>
+                  <Select value={selectedRepo} onValueChange={(val) => setSelectedRepo(val)}>
+                    <SelectTrigger id="repo-select">
+                      <SelectValue placeholder="Select repository" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {repos.map((repo) => (
+                        <SelectItem key={repo.repo_id} value={repo.repo_id}>
+                          {repo.repo_id}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="min-w-[220px]">
+                  <Label htmlFor="commit-select" className="sr-only">
+                    Commit
+                  </Label>
+                  <Select
+                    value={selectedCommitId}
+                    onValueChange={setSelectedCommitId}
+                    disabled={!snapshots.length}
+                  >
+                    <SelectTrigger id="commit-select">
+                      <SelectValue placeholder="Select commit" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {commitIds.map((commitId, idx) => (
+                        <SelectItem key={`${commitId}-${idx}`} value={commitId}>
+                          {commitId}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="min-w-[160px]">
+                  <Label htmlFor="format-select" className="sr-only">
+                    Format
+                  </Label>
+                  <Select
+                    value={exportFormat}
+                    onValueChange={(val) => setExportFormat(val as "json" | "graphml" | "csv")}
+                  >
+                    <SelectTrigger id="format-select">
+                      <SelectValue placeholder="Select format" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="json">JSON</SelectItem>
+                      <SelectItem value="graphml">GraphML</SelectItem>
+                      <SelectItem value="csv">CSV (nodes & edges)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Button
+                  className="ml-auto"
+                  onClick={() => handleDownload(exportFormat)}
+                  disabled={!selectedSnapshot}
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  Export
+                </Button>
+              </div>
+
+              {/* Row 2: query input / run / reset */}
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Describe the subgraph you want (e.g. 'show 100 functions')"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  className="w-full"
+                />
+                <Button onClick={handleQuerySubmit} disabled={!selectedRepo || !selectedCommitId || !query}>
+                  <Search className="mr-2 h-4 w-4" />
+                  Query
+                </Button>
+                <Button variant="outline" onClick={handleReset}>
+                  Reset
+                </Button>
+              </div>
+
+              {/* Quick suggestions */}
+              <div className="flex flex-wrap gap-2">
+                <Button size="sm" variant="secondary" onClick={() => setQuery("show 100 functions")}>
+                  Top 100 functions
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => setQuery("any calls")}>
+                  Any calls
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => setQuery("if/loop blocks")}>
+                  If/Loop blocks
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => setQuery("contributors")}>
+                  Contributors
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent>
+            {/* Fixed drawing area; GraphPreview always mounted */}
+            <div
+              className="w-full overflow-hidden rounded-md border border-border relative"
+              style={{ height: GRAPH_HEIGHT }}
+            >
+              <GraphPreview elements={previewElements} height={GRAPH_HEIGHT} />
+
+              {previewLoading && (
+                <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground bg-background/70 backdrop-blur">
+                  Loading…
+                </div>
+              )}
+
+              {!previewLoading && previewElements.length === 0 && (
+                <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
+                  No graph yet — choose a repo/commit and run a query.
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </MainContent>
+    </div>
+  );
 }

--- a/components/main-content.tsx
+++ b/components/main-content.tsx
@@ -28,7 +28,7 @@ export function MainContent({
       </Button>
       <main 
         className={cn(
-          "flex-1 min-h-screen transition-all duration-300",
+          "flex-1 min-h-0 transition-all duration-300",
           "flex flex-col",
           isCollapsed ? "md:pl-14" : "md:pl-4",
           "px-4 py-6 sm:px-6 lg:px-8",


### PR DESCRIPTION
## What
This PR streamlines the Code Graph page and makes the Cytoscape preview robust:

- **Single toolbar** for everything: repository selector, commit selector, download format, query input, and quick presets.
- **Cytoscape stability fixes** that eliminate `isHeadless` / `notify` null errors by guarding lifecycle edges and only running layouts when safe.
- **Better preview & export**: stable canvas sizing, PNG export, and snapshot-based GraphML/CSV downloads.

## Why
The split “Target & Export” vs “Query” made the flow jumpy and led to frequent layout churn. We also saw repeated runtime errors from Cytoscape when layouts/fit were triggered after the instance was destroyed or before the container had elements.

## Changes
- Create Cytoscape once; destroy on unmount; store in a ref with null/destroyed checks.
- Batch element updates and only `layout.run()` when there are elements.
- On `layoutstop`, call `cy.fit()` safely (skip if destroyed or no nodes).
- Add `validateElements()` to warn on malformed edges and missing ids.
- Persist selected node/edge colors from computed styles for the details panel.
- Merge repo/commit/format into the query toolbar; add preset query chips.
- Fix canvas layout thrash via fixed height and overflow controls.
- Export: PNG from canvas; snapshot-based GraphML/CSV with consistent filenames.
- Loading/empty/reset states.

## How I tested
- Loaded page with no selections → no errors, empty state shown.
- Selected repo + commit, ran multiple queries back-to-back → no Cytoscape errors; layout + fit behaved.
- Switched layouts and resized window → nodes retained, no re-init thrash.
- Downloaded PNG/GraphML/CSV → correct filenames, files open as expected.

## Rollout / Risks
- Low risk. UI moved but feature set is the same or improved.
- If issues arise, revert to previous layout container and conditional layout/fit calls.

## Checklist
- [x] No console errors during typical flows
- [x] Works on dark theme
- [x] Guarded all `cy` access with null/destroyed checks
- [x] Snapshot downloads verified